### PR TITLE
Add *.bat to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,7 @@ phase_*/
 
 # VS Code
 .history
+
+# Misc.
 build.py
+*.bat


### PR DESCRIPTION
People will probably need their own starting scripts and such, might as well make it easier on everyone.