### PR TITLE
feature: file autosaver

### DIFF
--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -3,15 +3,13 @@ import shutil
 import time
 import threading
 
+from .DNASerializer import DNASerializer
+
 
 class AutoSaver:
-    autoSaverInterval = 15  # Default auto saver interval
-    autoSaveCount = 0  # Number of saving iterations for one ouputFile
-    autoSaverMgrRunning = False
     autoSaverToggled = False
-
-    def __init__(self, DNASerializer = None):
-        AutoSaver.DNASerializer = DNASerializer
+    autoSaverInterval = 15.0
+    maxAutoSaveCount = 10
 
     @staticmethod
     def initializeAutoSaver():
@@ -24,24 +22,33 @@ class AutoSaver:
             # Loops without doing anything if auto saver isn't toggled
             if AutoSaver.autoSaverToggled is False:
                 time.sleep(0.1)
+
             while AutoSaver.autoSaverToggled is True:
-                endTime = time.time() + autoSaverInterval  # Epoch time of next auto save
-                # Loops until endTime is reached or the auto saver is un-toggled by user.
+                # outputFile filename is empty, which may occur if filename is left blank in file prompt
+                if DNASerializer.outputFile is None:
+                    print('No file loaded, exiting auto saving loop')
+                    DNASerializer.autoSaveCount = 0
+                    DNASerializer.autoSaverMgrRunning = False
+                    AutoSaver.autoSaverToggled = False
+                    break
+                # Epoch time of next auto save
+                endTime = time.time() + autoSaverInterval
+                # Loops until endTime is reached or the auto saver is un-toggled by user
                 while time.time() <= endTime and AutoSaver.autoSaverToggled is True:
                     time.sleep(0.1)
+                # Only auto save if auto save is toggled
                 if AutoSaver.autoSaverToggled is True:
                     AutoSaver.manageAutoSaveFiles()
-                    AutoSaver.autoSaveCount += 1
+                    DNASerializer.autoSaveCount += 1
 
     @staticmethod
     def manageAutoSaveFiles():
-        AutoSaver.autoSaverRunning = True
-        DNASerializer = AutoSaver.DNASerializer
-        autoSaveCount = AutoSaver.autoSaveCount
+        DNASerializer.autoSaverMgrRunning = True
+        autoSaveCount = DNASerializer.autoSaveCount
 
         # Sets max number of auto save files
-        if AutoSaver.autoSaveCount >= 10:
-            autoSaveCount = 10
+        if autoSaveCount >= AutoSaver.maxAutoSaveCount:
+            autoSaveCount = AutoSaver.maxAutoSaveCount
 
         # Defining outputFile name properties
         base = os.path.basename(DNASerializer.outputFile)
@@ -51,18 +58,21 @@ class AutoSaver:
         # Renames output file to auto save file naming convention
         if autoSaveCount == 0:
             DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension).replace('\\', '/')
-        basename = basename[:-6]  # Deletes 'latest' from filename
-        # Incrementally copies each auto save file (i.e. 3400_autosave-1.dna -> 3400_autosave-2.dna)
+
+        # Deletes 'latest' from filename
+        basename = basename[:-6]
+
+        # Copies auto save files
         while autoSaveCount != 0:
             filename = os.path.join(dir, basename + str(autoSaveCount) + extension)
             oldFilename = os.path.join(dir, basename + str(autoSaveCount - 1) + extension)
             # Copies working auto save file
             if autoSaveCount == 1:
                 shutil.copy2(DNASerializer.outputFile, filename)
-                print()
-            # Copies each numbered auto save file
+            # Incrementally copies each auto save file (i.e. 3400_autosave-1.dna -> 3400_autosave-2.dna)
             if autoSaveCount > 1:
                 shutil.copy2(oldFilename, filename)
             autoSaveCount -= 1
+
         DNASerializer.outputDNADefaultFile()  # Saves working DNA file
-        AutoSaver.autoSaverRunning = False
+        DNASerializer.autoSaverMgrRunning = False

--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -14,6 +14,10 @@ class AutoSaver:
     @staticmethod
     def initializeAutoSaver():
         threading.Thread(target = AutoSaver.autoSaverProcess, daemon = True).start()
+        # Creates 'autosaves' directory in user data directory
+        if not os.path.isdir('leveleditor/autosaves'):
+            os.mkdir('leveleditor/autosaves')
+            print('Created "autosaves" dir')
 
     @staticmethod
     def autoSaverProcess():
@@ -26,11 +30,12 @@ class AutoSaver:
             while AutoSaver.autoSaverToggled is True:
                 # outputFile filename is empty, which may occur if filename is left blank in file prompt
                 if DNASerializer.outputFile is None:
-                    print('No file loaded, exiting auto saving loop')
+                    print('No file loaded, exiting auto saving loop...')
                     DNASerializer.autoSaveCount = 0
                     DNASerializer.autoSaverMgrRunning = False
                     AutoSaver.autoSaverToggled = False
                     break
+
                 # Epoch time of next auto save
                 endTime = time.time() + autoSaverInterval
                 # Loops until endTime is reached or the auto saver is un-toggled by user
@@ -63,10 +68,14 @@ class AutoSaver:
                 if basename[-16:] == '_autosave-latest':
                     DNASerializer.outputDNADefaultFile()  # Saves working DNA file
                     return
-            DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension)
+            DNASerializer.outputFile = os.path.join(dir, 'autosaves', basename + '_autosave-latest' + extension)
+            # Replaces any back slashes in outputFile with forward slashes
+            DNASerializer.outputFile = DNASerializer.outputFile.replace('\\', '/')
+            # Creates new 'autosaves' directory if none is found
+            # This also accounts for if the directory of outputFile is not in the default user data folder
+            if not os.path.isdir(os.path.join(dir, 'autosaves')):
+                os.mkdir(os.path.join(dir, 'autosaves'))
 
-        # Change mix of separators to forward slashes
-        DNASerializer.outputFile.replace('\\', '/')
         # Deletes 'latest' from filename
         basename = basename[:-6]
 

--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -9,11 +9,11 @@ from .DNASerializer import DNASerializer
 class AutoSaver:
     autoSaverToggled = False
     autoSaverInterval = 15.0
-    maxAutoSaveCount = 10
+    maxAutoSaveCount = 10.0
 
     @staticmethod
     def initializeAutoSaver():
-        threading.Thread(target=AutoSaver.autoSaverProcess, daemon=True).start()
+        threading.Thread(target = AutoSaver.autoSaverProcess, daemon = True).start()
 
     @staticmethod
     def autoSaverProcess():
@@ -63,8 +63,10 @@ class AutoSaver:
                 if basename[-16:] == '_autosave-latest':
                     DNASerializer.outputDNADefaultFile()  # Saves working DNA file
                     return
-            DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension).replace('\\', '/')
+            DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension)
 
+        # Change mix of separators to forward slashes
+        DNASerializer.outputFile.replace('\\', '/')
         # Deletes 'latest' from filename
         basename = basename[:-6]
 

--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -48,7 +48,7 @@ class AutoSaver:
 
         # Sets max number of auto save files
         if autoSaveCount >= AutoSaver.maxAutoSaveCount:
-            autoSaveCount = AutoSaver.maxAutoSaveCount
+            autoSaveCount = int(AutoSaver.maxAutoSaveCount)
 
         # Defining outputFile name properties
         base = os.path.basename(DNASerializer.outputFile)
@@ -57,6 +57,12 @@ class AutoSaver:
 
         # Renames output file to auto save file naming convention
         if autoSaveCount == 0:
+            # Only save & manage 'latest' file
+            if AutoSaver.maxAutoSaveCount == 0:
+                # Only save auto save latest file
+                if basename[-16:] == '_autosave-latest':
+                    DNASerializer.outputDNADefaultFile()  # Saves working DNA file
+                    return
             DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension).replace('\\', '/')
 
         # Deletes 'latest' from filename

--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -39,16 +39,16 @@ class AutoSaver:
                 # Only auto save if auto save is toggled
                 if AutoSaver.autoSaverToggled is True:
                     AutoSaver.manageAutoSaveFiles()
-                    DNASerializer.autoSaveCount += 1
+                    # Sets autoSaveCount
+                    if DNASerializer.autoSaveCount >= AutoSaver.maxAutoSaveCount:
+                        DNASerializer.autoSaveCount = AutoSaver.maxAutoSaveCount
+                    else:
+                        DNASerializer.autoSaveCount += 1
 
     @staticmethod
     def manageAutoSaveFiles():
         DNASerializer.autoSaverMgrRunning = True
-        autoSaveCount = DNASerializer.autoSaveCount
-
-        # Sets max number of auto save files
-        if autoSaveCount >= AutoSaver.maxAutoSaveCount:
-            autoSaveCount = int(AutoSaver.maxAutoSaveCount)
+        autoSaveCount = int(DNASerializer.autoSaveCount)
 
         # Defining outputFile name properties
         base = os.path.basename(DNASerializer.outputFile)

--- a/toontown/leveleditor/AutoSaver.py
+++ b/toontown/leveleditor/AutoSaver.py
@@ -1,0 +1,68 @@
+import os
+import shutil
+import time
+import threading
+
+
+class AutoSaver:
+    autoSaverInterval = 15  # Default auto saver interval
+    autoSaveCount = 0  # Number of saving iterations for one ouputFile
+    autoSaverMgrRunning = False
+    autoSaverToggled = False
+
+    def __init__(self, DNASerializer = None):
+        AutoSaver.DNASerializer = DNASerializer
+
+    @staticmethod
+    def initializeAutoSaver():
+        threading.Thread(target=AutoSaver.autoSaverProcess, daemon=True).start()
+
+    @staticmethod
+    def autoSaverProcess():
+        while True:
+            autoSaverInterval = AutoSaver.autoSaverInterval * 60  # Converts global autoSaverInterval to minutes
+            # Loops without doing anything if auto saver isn't toggled
+            if AutoSaver.autoSaverToggled is False:
+                time.sleep(0.1)
+            while AutoSaver.autoSaverToggled is True:
+                endTime = time.time() + autoSaverInterval  # Epoch time of next auto save
+                # Loops until endTime is reached or the auto saver is un-toggled by user.
+                while time.time() <= endTime and AutoSaver.autoSaverToggled is True:
+                    time.sleep(0.1)
+                if AutoSaver.autoSaverToggled is True:
+                    AutoSaver.manageAutoSaveFiles()
+                    AutoSaver.autoSaveCount += 1
+
+    @staticmethod
+    def manageAutoSaveFiles():
+        AutoSaver.autoSaverRunning = True
+        DNASerializer = AutoSaver.DNASerializer
+        autoSaveCount = AutoSaver.autoSaveCount
+
+        # Sets max number of auto save files
+        if AutoSaver.autoSaveCount >= 10:
+            autoSaveCount = 10
+
+        # Defining outputFile name properties
+        base = os.path.basename(DNASerializer.outputFile)
+        dir = os.path.dirname(DNASerializer.outputFile)
+        basename, extension = os.path.splitext(base)
+
+        # Renames output file to auto save file naming convention
+        if autoSaveCount == 0:
+            DNASerializer.outputFile = os.path.join(dir, basename + '_autosave-latest' + extension).replace('\\', '/')
+        basename = basename[:-6]  # Deletes 'latest' from filename
+        # Incrementally copies each auto save file (i.e. 3400_autosave-1.dna -> 3400_autosave-2.dna)
+        while autoSaveCount != 0:
+            filename = os.path.join(dir, basename + str(autoSaveCount) + extension)
+            oldFilename = os.path.join(dir, basename + str(autoSaveCount - 1) + extension)
+            # Copies working auto save file
+            if autoSaveCount == 1:
+                shutil.copy2(DNASerializer.outputFile, filename)
+                print()
+            # Copies each numbered auto save file
+            if autoSaveCount > 1:
+                shutil.copy2(oldFilename, filename)
+            autoSaveCount -= 1
+        DNASerializer.outputDNADefaultFile()  # Saves working DNA file
+        AutoSaver.autoSaverRunning = False

--- a/toontown/leveleditor/DNASerializer.py
+++ b/toontown/leveleditor/DNASerializer.py
@@ -10,6 +10,7 @@ dnaDirectory = Filename.expandFrom(userfiles)
 class DNASerializer:
     notify = DirectNotifyGlobal.directNotify.newCategory('LevelEditor')
     outputFile = None
+    # Local AutoSaver variables
     autoSaverMgrRunning = False
     autoSaveCount = 0
 

--- a/toontown/leveleditor/DNASerializer.py
+++ b/toontown/leveleditor/DNASerializer.py
@@ -1,5 +1,5 @@
 from panda3d.core import Filename
-import os
+import os, shutil
 from tkinter import *
 from tkinter.filedialog import *
 from direct.directnotify import DirectNotifyGlobal
@@ -10,6 +10,8 @@ dnaDirectory = Filename.expandFrom(userfiles)
 class DNASerializer:
     notify = DirectNotifyGlobal.directNotify.newCategory('LevelEditor')
     outputFile = None
+    autoSaverRunning = False
+    autoSaveCount = 0
 
     # STYLE/DNA FILE FUNCTIONS
     @staticmethod
@@ -24,6 +26,11 @@ class DNASerializer:
                                       initialdir = path,
                                       title = 'Load DNA File',
                                       parent = base.le.panel.component('hull'))
+        DNASerializer.autoSaveCount = 0
+        # Wait until auto saver is done managing files before loading new file
+        while DNASerializer.autoSaverRunning is True:
+            if DNASerializer.autoSaverRunning is False:
+                break
         if dnaFilename:
             DNASerializer.loadDNAFromFile(dnaFilename)
             DNASerializer.outputFile = dnaFilename
@@ -42,6 +49,11 @@ class DNASerializer:
                 initialdir = path,
                 title = 'Save DNA File as',
                 parent = base.le.panel.component('hull'))
+        DNASerializer.autoSaveCount = 0
+        # Wait until auto saver is done managing files before saving new file
+        while DNASerializer.autoSaverRunning is True:
+            if DNASerializer.autoSaverRunning is False:
+                break
         if dnaFilename:
             DNASerializer.outputDNA(dnaFilename)
             DNASerializer.outputFile = dnaFilename
@@ -113,6 +125,32 @@ class DNASerializer:
         if ConfigVariableString("compiler") in ['libpandadna', 'clash']:
             print(f"Compiling PDNA for {ConfigVariableString('compiler')}")
             DNASerializer.compileDNA(binaryFilename)
+
+    @staticmethod
+    def manageAutoSaveFiles():
+        DNASerializer.autoSaverRunning = True
+        autoSaveCount = DNASerializer.autoSaveCount
+        # Sets max number of auto save files
+        if autoSaveCount >= 10:
+            autoSaveCount = 10
+        base = os.path.basename(os.path.abspath(DNASerializer.outputFile))
+        baseDir = os.path.dirname(os.path.abspath(DNASerializer.outputFile).replace('\\', '/'))
+        basename, extension = os.path.splitext(base)
+        # Renames output file to auto save file naming convention
+        if autoSaveCount == 0:
+            DNASerializer.outputFile = baseDir + '/' + basename + '_autosave-latest' + extension
+        basename = basename[:-6]  # Deletes 'latest' from filename
+        # Incrementally copies each auto save file
+        while autoSaveCount != 0:
+            filename = baseDir + '/' + basename + str(autoSaveCount) + extension
+            oldFilename = baseDir + '/' + basename + str(autoSaveCount - 1) + extension
+            if autoSaveCount == 1:
+                shutil.copy2(DNASerializer.outputFile, filename)
+            if autoSaveCount > 1:
+                shutil.copy2(oldFilename, filename)
+            autoSaveCount -= 1
+        DNASerializer.outputDNADefaultFile()  # Saves working DNA file
+        DNASerializer.autoSaverRunning = False
 
     @staticmethod
     def compileDNA(filename):

--- a/toontown/leveleditor/DNASerializer.py
+++ b/toontown/leveleditor/DNASerializer.py
@@ -3,7 +3,6 @@ import os
 from tkinter import *
 from tkinter.filedialog import *
 from direct.directnotify import DirectNotifyGlobal
-from .AutoSaver import AutoSaver
 
 dnaDirectory = Filename.expandFrom(userfiles)
 
@@ -11,7 +10,8 @@ dnaDirectory = Filename.expandFrom(userfiles)
 class DNASerializer:
     notify = DirectNotifyGlobal.directNotify.newCategory('LevelEditor')
     outputFile = None
-    dnaDirectory = dnaDirectory  # For AutoSaver.py
+    autoSaverMgrRunning = False
+    autoSaveCount = 0
 
     # STYLE/DNA FILE FUNCTIONS
     @staticmethod
@@ -26,10 +26,10 @@ class DNASerializer:
                                       initialdir = path,
                                       title = 'Load DNA File',
                                       parent = base.le.panel.component('hull'))
-        AutoSaver.autoSaveCount = 0
+        DNASerializer.autoSaveCount = 0
         # Wait until auto saver is done managing files before loading new file
-        while AutoSaver.autoSaverMgrRunning is True:
-            if AutoSaver.autoSaverMgrRunning is False:
+        while DNASerializer.autoSaverMgrRunning is True:
+            if DNASerializer.autoSaverMgrRunning is False:
                 break
         if dnaFilename:
             DNASerializer.loadDNAFromFile(dnaFilename)
@@ -49,10 +49,10 @@ class DNASerializer:
                 initialdir = path,
                 title = 'Save DNA File as',
                 parent = base.le.panel.component('hull'))
-        AutoSaver.autoSaveCount = 0
+        DNASerializer.autoSaveCount = 0
         # Wait until auto saver is done managing files before saving new file
-        while AutoSaver.autoSaverMgrRunning is True:
-            if AutoSaver.autoSaverMgrRunning is False:
+        while DNASerializer.autoSaverMgrRunning is True:
+            if DNASerializer.autoSaverMgrRunning is False:
                 break
         if dnaFilename:
             DNASerializer.outputDNA(dnaFilename)

--- a/toontown/leveleditor/LevelEditorPanel.py
+++ b/toontown/leveleditor/LevelEditorPanel.py
@@ -1562,17 +1562,16 @@ class LevelEditorPanel(Pmw.MegaToplevel):
         self.autoSaverDialog.focus_set()
 
     def setAutoSaverInterval(self, i):
-        if i == "Enter":
+        if i:
             try:
                 self.t = float(self.autoSaverDialogTextBox.get("1.0", 'end-1c'))
             except ValueError as e:
-                self.t = 15  # Resets to default value
+                # Non-float was passed
                 raise e
         self.autoSaverDialog.withdraw()
 
     def toggleAutoSaver(self):
-        # If no working DNA out file is selected, one is chosen here as a new specific
-        # out file can't be selected in the auto saver thread.
+        # If no working DNA outputFile is selected, one is chosen here.
         if DNASerializer.outputFile is None:
             DNASerializer.saveToSpecifiedDNAFile()
         if self.autoSaverToggled is False:
@@ -1589,13 +1588,10 @@ class LevelEditorPanel(Pmw.MegaToplevel):
             # Loops without doing anything if auto saver isn't toggled
             if self.autoSaverToggled is False:
                 time.sleep(0.1)
-            while self.autoSaverToggled is True:  # Only loops if auto saver is toggled
+            while self.autoSaverToggled is True:
                 endTime = time.time() + t  # Epoch time of next auto save interval based on t
                 while time.time() <= endTime and self.autoSaverToggled is True:
-                    # If no outfile is selected, prompt user to enter a new file in the main thread
-                    if DNASerializer.outputFile is None:
-                        self.toggleAutoSaver()
                     time.sleep(0.1)
                 if self.autoSaverToggled is True:
-                    DNASerializer.manageAutoSaveFiles()
+                    DNASerializer.manageAutoSaveFiles()  # Saves DNA file
                     DNASerializer.autoSaveCount += 1

--- a/toontown/leveleditor/LevelEditorPanel.py
+++ b/toontown/leveleditor/LevelEditorPanel.py
@@ -982,7 +982,7 @@ class LevelEditorPanel(Pmw.MegaToplevel):
         self.initialiseoptions(LevelEditorPanel)
 
         # Initializes auto saver for use
-        AutoSaver(DNASerializer).initializeAutoSaver()
+        AutoSaver.initializeAutoSaver()
 
     def updateInfo(self, page):
         if page == 'Signs':
@@ -1568,12 +1568,14 @@ class LevelEditorPanel(Pmw.MegaToplevel):
             self.levelEditor.useDirectFly()
 
     def toggleAutoSaver(self):
-        # If no working DNA outputFile is selected, one is chosen here.
-        if DNASerializer.outputFile is None:
-            DNASerializer.saveToSpecifiedDNAFile()
         if AutoSaver.autoSaverToggled is False:
+            # If no working DNA outputFile is selected, one is chosen here
+            if DNASerializer.outputFile is None:
+                DNASerializer.saveToSpecifiedDNAFile()
+            print(f'Started auto saver on an interval of {AutoSaver.autoSaverInterval} minutes')
             # Toggles auto saver to begin auto saving loop
             AutoSaver.autoSaverToggled = True
         else:
+            print('Stopped auto saver process')
             # Stops auto saving loop
             AutoSaver.autoSaverToggled = False

--- a/toontown/leveleditor/LevelEditorPanel.py
+++ b/toontown/leveleditor/LevelEditorPanel.py
@@ -1595,6 +1595,6 @@ class LevelEditorPanel(Pmw.MegaToplevel):
             # Toggles auto saver to begin auto saving loop
             AutoSaver.autoSaverToggled = True
         else:
-            print('Stopping auto saver')
+            print('Stopping auto saver...')
             # Stops auto saving loop
             AutoSaver.autoSaverToggled = False

--- a/toontown/leveleditor/LevelEditorPanel.py
+++ b/toontown/leveleditor/LevelEditorPanel.py
@@ -187,32 +187,31 @@ class LevelEditorPanel(Pmw.MegaToplevel):
                                                 message_text = CONTROLS)
         self.controlsDialog.withdraw()
 
-        self.autoSaverDialog = Pmw.Dialog(parent, title='Autosaver Options',
-                                          buttons=('Save Options',),
-                                          command=self.setAutoSaverInterval
-                                          )
+        self.autoSaverDialog = Pmw.Dialog(parent, title = 'Autosaver Options',
+                                          buttons = ('Save Options',),
+                                          command = self.setAutoSaverInterval)
         self.autoSaverDialog.withdraw()
 
         self.autoSaverDialogInterval = Pmw.Counter(self.autoSaverDialog.interior(),
-                                                   labelpos='w',
+                                                   labelpos = 'w',
                                                    label_text = 'Auto save interval in minutes:',
-                                                   entry_width=10,
+                                                   entry_width = 10,
                                                    entryfield_value = int(AutoSaver.autoSaverInterval),
-                                                   entryfield_validate={'validator': 'real',
+                                                   entryfield_validate = {'validator': 'real',
                                                                         'min': 1, 'max': 60})
 
         self.autoSaverDialogMax = Pmw.Counter(self.autoSaverDialog.interior(),
-                                              labelpos='w',
+                                              labelpos = 'w',
                                               label_text = 'Max auto save files:',
-                                              entry_width=10,
+                                              entry_width = 10,
                                               entryfield_value = int(AutoSaver.maxAutoSaveCount),
-                                              entryfield_validate={'validator': 'numeric',
+                                              entryfield_validate = {'validator': 'numeric',
                                                                    'min': 0, 'max': 99})
 
         counters = (self.autoSaverDialogInterval, self.autoSaverDialogMax)
         Pmw.alignlabels(counters)
         for counter in counters:
-            counter.pack(fill='both', expand=1, padx=10, pady=10)
+            counter.pack(fill = 'both', expand = 1)
 
         self.editMenu = Pmw.ComboBox(
                 menuFrame, labelpos = W,
@@ -1592,10 +1591,10 @@ class LevelEditorPanel(Pmw.MegaToplevel):
             # If no working DNA outputFile is selected, one is chosen here
             if DNASerializer.outputFile is None:
                 DNASerializer.saveToSpecifiedDNAFile()
-            print(f'Started auto saver on an interval of {AutoSaver.autoSaverInterval} minutes')
+            print(f'Starting auto saver on an interval of {AutoSaver.autoSaverInterval} minutes')
             # Toggles auto saver to begin auto saving loop
             AutoSaver.autoSaverToggled = True
         else:
-            print('Stopped auto saver process')
+            print('Stopping auto saver')
             # Stops auto saving loop
             AutoSaver.autoSaverToggled = False

--- a/toontown/leveleditor/LevelEditorPanel.py
+++ b/toontown/leveleditor/LevelEditorPanel.py
@@ -131,11 +131,11 @@ class LevelEditorPanel(Pmw.MegaToplevel):
         menuBar.addmenuitem('Advanced', 'separator')
         menuBar.addmenuitem('Advanced', 'checkbutton',
                             'Toggle Auto-saver On/Off',
-                            label =  'Toggle Auto-Saver',
+                            label =  'Toggle Auto Saver',
                             command = self.toggleAutoSaver)
         menuBar.addmenuitem('Advanced', 'command',
-                            'User Set Auto Saver Interval',
-                            label = 'Set Auto-Saver Interval',
+                            'User Set Auto Saver Options',
+                            label = 'Auto Saver Options',
                             command = self.showAutoSaverDialog)
 
         # Corporate Clash Old Toontown-esque Filter
@@ -187,13 +187,32 @@ class LevelEditorPanel(Pmw.MegaToplevel):
                                                 message_text = CONTROLS)
         self.controlsDialog.withdraw()
 
-        self.autoSaverDialog = Pmw.Dialog(parent,
-                                          title = 'Set Auto-Saver Interval (in minutes)',
-                                          buttons = ('Enter',),
-                                          command = self.setAutoSaverInterval)
+        self.autoSaverDialog = Pmw.Dialog(parent, title='Autosaver Options',
+                                          buttons=('Save Options',),
+                                          command=self.setAutoSaverInterval
+                                          )
         self.autoSaverDialog.withdraw()
-        self.autoSaverDialogTextBox = Text(self.autoSaverDialog.interior(), height = 10)
-        self.autoSaverDialogTextBox.pack(expand = 1, fill = BOTH)
+
+        self.autoSaverDialogInterval = Pmw.Counter(self.autoSaverDialog.interior(),
+                                                   labelpos='w',
+                                                   label_text = 'Auto save interval in minutes:',
+                                                   entry_width=10,
+                                                   entryfield_value = int(AutoSaver.autoSaverInterval),
+                                                   entryfield_validate={'validator': 'real',
+                                                                        'min': 1, 'max': 60})
+
+        self.autoSaverDialogMax = Pmw.Counter(self.autoSaverDialog.interior(),
+                                              labelpos='w',
+                                              label_text = 'Max auto save files:',
+                                              entry_width=10,
+                                              entryfield_value = int(AutoSaver.maxAutoSaveCount),
+                                              entryfield_validate={'validator': 'numeric',
+                                                                   'min': 0, 'max': 99})
+
+        counters = (self.autoSaverDialogInterval, self.autoSaverDialogMax)
+        Pmw.alignlabels(counters)
+        for counter in counters:
+            counter.pack(fill='both', expand=1, padx=10, pady=10)
 
         self.editMenu = Pmw.ComboBox(
                 menuFrame, labelpos = W,
@@ -1489,9 +1508,10 @@ class LevelEditorPanel(Pmw.MegaToplevel):
         self.levelEditor.currentBattleCellType = name
 
     def setAutoSaverInterval(self, i):
-        if i == 'Enter':
+        if i == 'Save Options':
             try:
-                AutoSaver.autoSaverInterval = float(self.autoSaverDialogTextBox.get("1.0", 'end-1c'))
+                AutoSaver.autoSaverInterval = float(self.autoSaverDialogInterval.get())
+                AutoSaver.maxAutoSaveCount = float(self.autoSaverDialogMax.get())
             except ValueError as e:
                 # Non-float was passed
                 raise e


### PR DESCRIPTION
Added an auto saver feature to the level editor.   It currently features:
* Toggleable auto saver function - Saves current working file on an interval and copies to a set number of history files.  Each autosave file is incrementally copied to a set number (10 by default.)  The auto saver can be toggled off by the user at any time, and will still continue if a new file is loaded/saved to.
* Auto saver interval, alongside the number of autosave files to save, can be changed by the user

![image](https://user-images.githubusercontent.com/48182689/104685491-2a1eaa00-56c9-11eb-8555-1114f19e0345.png)
<sub>Auto saver menu buttons</sub>

![image](https://user-images.githubusercontent.com/48182689/104685550-56d2c180-56c9-11eb-87ca-d89098ffcb60.png)
<sub>Auto saver options dialog</sub>

![image](https://user-images.githubusercontent.com/48182689/104685755-c9dc3800-56c9-11eb-9f32-49018423fb53.png)
<sub>Example of 2 DNA files with the autosaver enabled. </sub>

I have tested this so far on Windows running on the latest build of Panda3D and libdisney with no issues.